### PR TITLE
テストケース見直し。連続購入をするとお釣りの計算が合わない。

### DIFF
--- a/Vending.Test/UnitTest1.cs
+++ b/Vending.Test/UnitTest1.cs
@@ -44,7 +44,7 @@ namespace Vending.Test
             Assert.Null(drink);
         }
 
-        [Fact(DisplayName = "’Ş‘KØ‚ê")]
+        [Fact(DisplayName = "’Ş‘KØ‚ê1")]
         public void Test4()
         {
             var vm = new VendingMachine();
@@ -53,6 +53,7 @@ namespace Vending.Test
             for (var i = 0; i < cnt; i++)
             {
                 _ = vm.Buy(500, Drink.COKE);
+                _ = vm.Refund();
             }
 
             var drink = vm.Buy(500, Drink.COKE);
@@ -60,21 +61,26 @@ namespace Vending.Test
             Assert.Null(drink);
         }
 
-        [Fact(DisplayName = "’Ş‘KØ‚ê")]
+        [Fact(DisplayName = "’Ş‘KØ‚ê2")]
         public void Test5()
         {
             var vm = new VendingMachine();
 
             // ’Ş‘K800‰~Á”ï c‚è200‰~
             _ = vm.Buy(500, Drink.COKE);
+            _ = vm.Refund();
             _ = vm.Buy(500, Drink.COKE);
+            _ = vm.Refund();
 
             // ’Ş‘K200‰~’Ç‰Á c‚è400‰~
             _ = vm.Buy(100, Drink.COKE);
+            _ = vm.Refund();
             _ = vm.Buy(100, Drink.COKE);
+            _ = vm.Refund();
 
             // ’Ş‘K400‰~Á”ï c‚è0‰~
             var coke = vm.Buy(500, Drink.COKE);
+            _ = vm.Refund();
 
             // ’Ş‘K‚È‚µ ‚Â‚¢‚Å‚ÉCOKE‚àİŒÉØ‚ê‚È‚Ì‚ÅDIET_COKE‚É•ÏX
             var dietCoke = vm.Buy(500, Drink.DIET_COKE);


### PR DESCRIPTION
例：500円玉で購入を6回繰り返した場合、投入金額が3,000円、代金が600円なのでお釣りは2,400円。
投入した500円玉4枚＋もともとあった100円玉4枚でお釣りは出せるはず。
下記いずれかであるべき。
・500円玉を投入した場合、必ず100円玉のストックが減るのをやめる。
    ＝ 投入金額も勘案して釣銭切れやお釣りの金額を都度判定する。
・購入後、必ずお釣りを返却するようにする。